### PR TITLE
Bump to latest major version

### DIFF
--- a/src/Dynatello/Dynatello.csproj
+++ b/src/Dynatello/Dynatello.csproj
@@ -20,8 +20,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DynamoDBGenerator" Version="1.2.2"/>
-        <PackageReference Include="DynamoDBGenerator.SourceGenerator" Version="1.2.2"/>
+        <PackageReference Include="DynamoDBGenerator" Version="2.0.1"/>
+        <PackageReference Include="DynamoDBGenerator.SourceGenerator" Version="2.0.1"/>
     </ItemGroup>
 
 </Project>

--- a/src/Dynatello/Handlers/GetRequestHandler.cs
+++ b/src/Dynatello/Handlers/GetRequestHandler.cs
@@ -46,6 +46,6 @@ internal sealed class GetRequestHandler<TArg, T> : IRequestHandler<TArg, T?>
                 cancellationToken
             );
 
-        return response.IsItemSet ? _createItem(response.Item) : default;
+        return response.IsItemSet && response.Item.Count > 0 ? _createItem(response.Item) : default;
     }
 }

--- a/src/Dynatello/Handlers/GetRequestHandler.cs
+++ b/src/Dynatello/Handlers/GetRequestHandler.cs
@@ -46,6 +46,6 @@ internal sealed class GetRequestHandler<TArg, T> : IRequestHandler<TArg, T?>
                 cancellationToken
             );
 
-        return response.IsItemSet && response.Item.Count > 0 ? _createItem(response.Item) : default;
+        return response.IsItemSet ? _createItem(response.Item) : default;
     }
 }

--- a/src/Dynatello/Handlers/GetRequestHandler.cs
+++ b/src/Dynatello/Handlers/GetRequestHandler.cs
@@ -1,3 +1,4 @@
+using Amazon;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using DynamoDBGenerator.Exceptions;
@@ -46,6 +47,8 @@ internal sealed class GetRequestHandler<TArg, T> : IRequestHandler<TArg, T?>
                 cancellationToken
             );
 
-        return response.IsItemSet ? _createItem(response.Item) : default;
+        return response.IsItemSet is false || response.Item is null || response.Item.Count is 0
+            ? default
+            : _createItem(response.Item);
     }
 }

--- a/tests/Dynatello.Tests/HandlerTests/DeleteRequestHandlerTests.cs
+++ b/tests/Dynatello.Tests/HandlerTests/DeleteRequestHandlerTests.cs
@@ -32,7 +32,7 @@ public class DeleteRequestHandlerTests
                 x => x.ToDeleteRequestBuilder() with { ReturnValues = ReturnValue.ALL_OLD },
                 x => x.AmazonDynamoDB = amazonDynamoDB
             )
-            .Send(expected.Id, default);
+            .Send(expected.Id, CancellationToken.None);
 
         Assert.Equal(expected, actual);
     }
@@ -53,7 +53,7 @@ public class DeleteRequestHandlerTests
                 x => x.ToDeleteRequestBuilder(),
                 x => x.AmazonDynamoDB = amazonDynamoDB
             )
-            .Send(expected.Id, default);
+            .Send(expected.Id, CancellationToken.None);
 
         Assert.Null(actual);
     }

--- a/tests/Dynatello.Tests/HandlerTests/GetRequestHandlerTests.cs
+++ b/tests/Dynatello.Tests/HandlerTests/GetRequestHandlerTests.cs
@@ -79,7 +79,8 @@ public class GetRequestHandlerTests
             false,
             pipeLineTimestamps.Zip(
                 pipeLineTimestamps.Skip(1),
-                (x, y) => x < y && y - x < TimeSpan.FromMilliseconds(100) // ugly hack to verify that request comes last.
+                (x, y) => x < y &&
+                          y - x < TimeSpan.FromMilliseconds(100) // ugly hack to verify that request comes last.
             )
         );
     }
@@ -120,7 +121,7 @@ public class GetRequestHandlerTests
 
         amazonDynamoDB
             .GetItemAsync(Arg.Any<GetItemRequest>())
-            .Returns(new GetItemResponse { IsItemSet = false});
+            .Returns(new GetItemResponse { IsItemSet = false, Item = null });
 
         var actual = await Cat
             .GetById.OnTable("TABLE")

--- a/tests/Dynatello.Tests/HandlerTests/GetRequestHandlerTests.cs
+++ b/tests/Dynatello.Tests/HandlerTests/GetRequestHandlerTests.cs
@@ -48,11 +48,11 @@ public class GetRequestHandlerTests
 
         var pipelines = new TestPipeLine[]
         {
-            new TestPipeLine(),
-            new TestPipeLine(),
-            new TestPipeLine(),
-            new TestPipeLine(),
-            new TestPipeLine(),
+            new(),
+            new(),
+            new(),
+            new(),
+            new(),
         };
 
         Assert.All(pipelines, x => Assert.Null(x.TimeStamp));
@@ -70,7 +70,7 @@ public class GetRequestHandlerTests
                     x.AmazonDynamoDB = amazonDynamoDB;
                 }
             )
-            .Send(expected.Id, default);
+            .Send(expected.Id, CancellationToken.None);
         Assert.Equal(expected, actual);
         Assert.All(pipelines, x => Assert.NotNull(x.TimeStamp));
         var pipeLineTimestamps = pipelines.Select(x => x.TimeStamp!.Value).ToArray();
@@ -79,7 +79,7 @@ public class GetRequestHandlerTests
             false,
             pipeLineTimestamps.Zip(
                 pipeLineTimestamps.Skip(1),
-                (x, y) => (x < y) && (y - x) < TimeSpan.FromMilliseconds(100) // ugly hack to verify that request comes last.
+                (x, y) => x < y && y - x < TimeSpan.FromMilliseconds(100) // ugly hack to verify that request comes last.
             )
         );
     }
@@ -107,7 +107,7 @@ public class GetRequestHandlerTests
                 x => x.ToGetRequestBuilder(),
                 x => x.AmazonDynamoDB = amazonDynamoDB
             )
-            .Send(expected.Id, default);
+            .Send(expected.Id, CancellationToken.None);
 
         Assert.Equal(expected, actual);
     }
@@ -120,7 +120,7 @@ public class GetRequestHandlerTests
 
         amazonDynamoDB
             .GetItemAsync(Arg.Any<GetItemRequest>())
-            .Returns(new GetItemResponse { IsItemSet = false, Item = null}); // does not succeed with empty dictionary
+            .Returns(new GetItemResponse { IsItemSet = false});
 
         var actual = await Cat
             .GetById.OnTable("TABLE")

--- a/tests/Dynatello.Tests/HandlerTests/GetRequestHandlerTests.cs
+++ b/tests/Dynatello.Tests/HandlerTests/GetRequestHandlerTests.cs
@@ -13,7 +13,7 @@ public class GetRequestHandlerTests
 {
     private class TestPipeLine : IRequestPipeLine
     {
-        public DateTime? TimeStamp = null;
+        public DateTime? TimeStamp;
 
         public async Task<AmazonWebServiceResponse> Invoke(
             RequestContext requestContext,
@@ -120,7 +120,7 @@ public class GetRequestHandlerTests
 
         amazonDynamoDB
             .GetItemAsync(Arg.Any<GetItemRequest>())
-            .Returns(new GetItemResponse { IsItemSet = false });
+            .Returns(new GetItemResponse { IsItemSet = false, Item = null}); // does not succeed with empty dictionary
 
         var actual = await Cat
             .GetById.OnTable("TABLE")
@@ -128,8 +128,8 @@ public class GetRequestHandlerTests
                 x => x.ToGetRequestBuilder(),
                 x => x.AmazonDynamoDB = amazonDynamoDB
             )
-            .Send(expected.Id, default);
+            .Send(expected.Id, CancellationToken.None);
 
-        Assert.Equal((Cat)null!, actual);
+        Assert.Equal(null!, actual);
     }
 }

--- a/tests/Dynatello.Tests/HandlerTests/PutRequestHandlerTests.cs
+++ b/tests/Dynatello.Tests/HandlerTests/PutRequestHandlerTests.cs
@@ -35,7 +35,7 @@ public class PutRequestHandlerTests
                 x => x.ToPutRequestBuilder() with { ReturnValues = new ReturnValue(returnValue) },
                 x => x.AmazonDynamoDB = amazonDynamoDB
             )
-            .Send(expected, default);
+            .Send(expected, CancellationToken.None);
 
         Assert.Equal(expected, actual);
     }
@@ -64,7 +64,7 @@ public class PutRequestHandlerTests
                     },
                 x => x.AmazonDynamoDB = amazonDynamoDB
             )
-            .Send(expected, default);
+            .Send(expected, CancellationToken.None);
 
         Assert.Equal(actual, null);
     }

--- a/tests/Dynatello.Tests/HandlerTests/QueryRequestHandlerTests.cs
+++ b/tests/Dynatello.Tests/HandlerTests/QueryRequestHandlerTests.cs
@@ -31,10 +31,10 @@ public class QueryRequestHandlerTests
             .ToQueryRequestHandler(
                 x =>
                     x.WithKeyConditionExpression((x, y) => $"{x.Id} = {y.Id}")
-                        .ToQueryRequestBuilder() with
-                    {
-                        IndexName = "INDEX",
-                    },
+                            .ToQueryRequestBuilder() with
+                        {
+                            IndexName = "INDEX",
+                        },
                 x => x.AmazonDynamoDB = amazonDynamoDB
             )
             .Send((Guid.NewGuid(), 2), CancellationToken.None);
@@ -51,8 +51,7 @@ public class QueryRequestHandlerTests
         var chunks = Cat
             .Fixture.CreateMany<Cat>(elementCount)
             .Chunk(chunkCount)
-            .Select(
-                (elements, index) =>
+            .Select((elements, index) =>
                 {
                     var lastId = elements[^1].Id.ToString();
                     var key =
@@ -108,10 +107,10 @@ public class QueryRequestHandlerTests
             .ToQueryRequestHandler(
                 x =>
                     x.WithKeyConditionExpression(static (x, y) => $"{x.Id} = {y.Id}")
-                        .ToQueryRequestBuilder() with
-                    {
-                        IndexName = "INDEX"
-                    },
+                            .ToQueryRequestBuilder() with
+                        {
+                            IndexName = "INDEX"
+                        },
                 x => x.AmazonDynamoDB = amazonDynamoDB
             )
             .Send((Guid.NewGuid(), 2), CancellationToken.None);

--- a/tests/Dynatello.Tests/HandlerTests/QueryRequestHandlerTests.cs
+++ b/tests/Dynatello.Tests/HandlerTests/QueryRequestHandlerTests.cs
@@ -30,7 +30,7 @@ public class QueryRequestHandlerTests
             .QueryWithCuteness.OnTable("TABLE")
             .ToQueryRequestHandler(
                 x =>
-                    x.WithKeyConditionExpression(((x, y) => $"{x.Id} = {y.Id}"))
+                    x.WithKeyConditionExpression((x, y) => $"{x.Id} = {y.Id}")
                         .ToQueryRequestBuilder() with
                     {
                         IndexName = "INDEX",

--- a/tests/Dynatello.Tests/HandlerTests/QueryRequestHandlerTests.cs
+++ b/tests/Dynatello.Tests/HandlerTests/QueryRequestHandlerTests.cs
@@ -77,7 +77,9 @@ public class QueryRequestHandlerTests
         amazonDynamoDB
             .QueryAsync(
                 Arg.Is<QueryRequest>(x =>
-                    x.ExclusiveStartKey.Count == 0 || x.ExclusiveStartKey[nameof(Cat.Id)] != null
+                    x.ExclusiveStartKey == null 
+                    || x.ExclusiveStartKey.Count == 0 
+                    || x.ExclusiveStartKey[nameof(Cat.Id)] != null
                 ),
                 Arg.Any<CancellationToken>()
             )

--- a/tests/Dynatello.Tests/HandlerTests/UpdateRequestHandlerTests.cs
+++ b/tests/Dynatello.Tests/HandlerTests/UpdateRequestHandlerTests.cs
@@ -42,7 +42,7 @@ public class UpdateRequestHandlerTests
                     },
                 x => x.AmazonDynamoDB = amazonDynamoDB
             )
-            .Send((expected.Id, expected.HomeId), default);
+            .Send((expected.Id, expected.HomeId), CancellationToken.None);
 
         Assert.Equal(expected, actual);
     }
@@ -72,7 +72,7 @@ public class UpdateRequestHandlerTests
                     },
                 x => x.AmazonDynamoDB = amazonDynamoDB
             )
-            .Send((Guid.NewGuid(), Guid.NewGuid()), default);
+            .Send((Guid.NewGuid(), Guid.NewGuid()), CancellationToken.None);
 
         Assert.Equal(null, actual);
     }

--- a/tests/Dynatello.Tests/ToDeleteItemRequestTests.cs
+++ b/tests/Dynatello.Tests/ToDeleteItemRequestTests.cs
@@ -254,7 +254,7 @@ public class ToDeleteItemRequestTests
                                 },
                             },
                             TableName = "TABLE",
-                            ExpressionAttributeNames = new Dictionary<string, string>(),
+                            ExpressionAttributeNames = null,
                             ReturnConsumedCapacity = null,
                         }
                     )
@@ -290,7 +290,7 @@ public class ToDeleteItemRequestTests
                                 },
                             },
                             TableName = "TABLE",
-                            ExpressionAttributeNames = new Dictionary<string, string>(),
+                            ExpressionAttributeNames = null,
                             ReturnConsumedCapacity = null,
                         }
                     )

--- a/tests/Dynatello.Tests/ToGetItemRequestTests.cs
+++ b/tests/Dynatello.Tests/ToGetItemRequestTests.cs
@@ -93,11 +93,11 @@ public class ToGetItemRequestTests
                                 },
                             },
                             TableName = "TABLE",
-                            ConsistentRead = false,
-                            ExpressionAttributeNames = new Dictionary<string, string>(),
+                            ConsistentRead = null,
+                            ExpressionAttributeNames = null,
                             ProjectionExpression = null,
                             ReturnConsumedCapacity = null,
-                            AttributesToGet = new List<string>(),
+                            AttributesToGet = null,
                         }
                     )
             );
@@ -132,11 +132,11 @@ public class ToGetItemRequestTests
                                 },
                             },
                             TableName = "TABLE",
-                            ConsistentRead = false,
-                            ExpressionAttributeNames = new Dictionary<string, string>(),
+                            ConsistentRead = null,
+                            ExpressionAttributeNames = null,
                             ProjectionExpression = null,
                             ReturnConsumedCapacity = null,
-                            AttributesToGet = new List<string>(),
+                            AttributesToGet = null,
                         }
                     )
             );

--- a/tests/Dynatello.Tests/ToQueryRequestTests.cs
+++ b/tests/Dynatello.Tests/ToQueryRequestTests.cs
@@ -47,14 +47,14 @@ public class ToQueryRequestTests
                             ReturnConsumedCapacity = null,
                             FilterExpression = null,
                             Limit = 0,
-                            ConsistentRead = false,
+                            ConsistentRead = null,
                             Select = null,
                             ProjectionExpression = null,
                             IndexName = null,
                             QueryFilter = null,
-                            ExclusiveStartKey = new Dictionary<string, AttributeValue>(),
+                            ExclusiveStartKey = null,
                             IsLimitSet = false,
-                            ScanIndexForward = false,
+                            ScanIndexForward = null
                         }
                     );
             });
@@ -109,14 +109,14 @@ public class ToQueryRequestTests
                             ReturnConsumedCapacity = null,
                             FilterExpression = "#Cuteness > :p2",
                             Limit = 0,
-                            ConsistentRead = false,
+                            ConsistentRead = null,
                             Select = null,
                             ProjectionExpression = null,
                             IndexName = null,
                             QueryFilter = null,
-                            ExclusiveStartKey = new Dictionary<string, AttributeValue>(),
+                            ExclusiveStartKey = null,
                             IsLimitSet = false,
-                            ScanIndexForward = false,
+                            ScanIndexForward = null
                         }
                     );
             });


### PR DESCRIPTION
# Summary
This PR upgrades the Amazon DynamoDB dependencies to version 4. The most significant breaking change in this release is that internal collection properties in DynamoDB models no longer default to empty collections. Instead, these properties may now be null depending on the global settings of the SDK.

## Key Changes
### Dependency Updates:
DynamoDBGenerator and DynamoDBGenerator.SourceGenerator updated from 1.2.4 to 2.0.1 in Dynatello.csproj.
### Handler Updates:
Adjusted logic in request handlers (such as GetRequestHandler, QueryRequestHandler) to account for collection properties potentially being null rather than empty collections.
Conditional checks now handle both null and empty collection cases to prevent null reference issues.
### Test Suite Updates:
Test mocks and assertions updated to accommodate the new null behavior for collections and request parameters (e.g., ExpressionAttributeNames, AttributesToGet, etc. now may be null).
Standardized on using CancellationToken.None in handler tests.
### Code Style:
Minor code style tweaks to match modern C# conventions (object initializers, use of static, simplified array initializers).
Migration Notes
### Null Checks:
If you have custom code depending on empty collection defaults, review and add null checks as needed after consuming this version.
### SDK Settings:
The actual behavior regarding collections may depend on your DynamoDB SDK global configuration.